### PR TITLE
Fix well-known URI, add support for CoRE Link Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Notice that `"queryEndpoint"`and `"updateEndpoint"` must have as value the corre
 
 | Endpoint 	| Method 	| Headers 	| Reference 	| Description 	|
 |---	|---	|---	|---	|---	|
-| `/.well-known/wot-thing-description` 	| `GET` 	| `N/A` 	| [Introduction Mechanim](https://w3c.github.io/wot-discovery/#introduction-well-known) 	| Provides the Thing Description of the WoT Hive directory 	|
+| `/.well-known/wot` 	| `GET` 	| `N/A` 	| [Introduction Mechanism](https://w3c.github.io/wot-discovery/#introduction-well-known) 	| Provides the Thing Description of the WoT Hive directory 	|
 | `/configuration` 	| `GET` 	| `N/A` 	| [Management](https://w3c.github.io/wot-discovery/#exploration-directory-api-management) 	| Provides a JSON with the all the configurations of the WoT Hive 	|
 | `/configuration` 	| `POST` 	| `N/A` 	| [Management](https://w3c.github.io/wot-discovery/#exploration-directory-api-management) 	| The body of the request must contain a JSON with all the configurations of the WoT Hive. 	|
 | `/api/things{?offset,limit,sort_by,sort_order}` 	| `GET` 	| `Accept`: `application/td+json`or `text/turtle`  	| [Listing](https://w3c.github.io/wot-discovery/#exploration-directory-api-registration-listing) 	| Provides a listing of the stored Thing Descriptions in JSON-LD framed or Turtle 	|

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Notice that `"queryEndpoint"`and `"updateEndpoint"` must have as value the corre
 | Endpoint 	| Method 	| Headers 	| Reference 	| Description 	|
 |---	|---	|---	|---	|---	|
 | `/.well-known/wot` 	| `GET` 	| `N/A` 	| [Introduction Mechanism](https://w3c.github.io/wot-discovery/#introduction-well-known) 	| Provides the Thing Description of the WoT Hive directory 	|
+| `/.well-known/core` 	| `GET` 	| `N/A` 	| [Introduction Mechanim](https://w3c.github.io/wot-discovery/#introduction-core-rd-sec) 	| Exposes the directory's Thing Description using the CoRE Link Format	|
 | `/configuration` 	| `GET` 	| `N/A` 	| [Management](https://w3c.github.io/wot-discovery/#exploration-directory-api-management) 	| Provides a JSON with the all the configurations of the WoT Hive 	|
 | `/configuration` 	| `POST` 	| `N/A` 	| [Management](https://w3c.github.io/wot-discovery/#exploration-directory-api-management) 	| The body of the request must contain a JSON with all the configurations of the WoT Hive. 	|
 | `/api/things{?offset,limit,sort_by,sort_order}` 	| `GET` 	| `Accept`: `application/td+json`or `text/turtle`  	| [Listing](https://w3c.github.io/wot-discovery/#exploration-directory-api-registration-listing) 	| Provides a listing of the stored Thing Descriptions in JSON-LD framed or Turtle 	|

--- a/src/main/java/directory/Directory.java
+++ b/src/main/java/directory/Directory.java
@@ -69,6 +69,7 @@ public class Directory {
 		path("/.well-known", () -> {
 			get("/wot", Directory.getSelfDescription);
 			exception(SelfDescriptionException.class,SelfDescriptionException.handleSelfDescriptionException);
+			get("/core", Directory.getCoreResources);
 		});
 		path("/configuration", () -> {
 			get("", DirectoryConfigurationController.configuration);
@@ -159,6 +160,11 @@ public class Directory {
 		}
 
 		};
+
+	public static final Route getCoreResources = (Request request, Response response) -> {
+		response.header(Utils.HEADER_CONTENT_TYPE, Utils.MIME_LINK_FORMAT);
+		return "</.well-known/wot>;rt=\"wot.directory\";ct=432";
+	};
 
 	private static String handleUnmatchedRoutes(Request request, Response response, int status) {
 		response.type(Utils.MIME_JSON);

--- a/src/main/java/directory/Directory.java
+++ b/src/main/java/directory/Directory.java
@@ -62,12 +62,14 @@ public class Directory {
 
 	// -- Main method
 	@SuppressWarnings("unchecked")
-	public static void main(String[] args) {		
+	public static void main(String[] args) {
 		setup();
 		//SparkSwagger.of()
-		
-		get("/.well-known/wot-thing-description", Directory.getSelfDescription);
-		exception(SelfDescriptionException.class,SelfDescriptionException.handleSelfDescriptionException);
+
+		path("/.well-known", () -> {
+			get("/wot", Directory.getSelfDescription);
+			exception(SelfDescriptionException.class,SelfDescriptionException.handleSelfDescriptionException);
+		});
 		path("/configuration", () -> {
 			get("", DirectoryConfigurationController.configuration);
 			get("/service", DirectoryConfigurationController.serviceConfiguration);
@@ -79,10 +81,10 @@ public class Directory {
 			post("/validation", DirectoryConfigurationController.configureValidation);
 			exception(ConfigurationException.class,ConfigurationException.handleConfigurationException);
 		});
-		
-		
+
+
 		path("/api", () -> {
-			
+
 			path("/search", () -> {
 				get("/jsonpath", JsonPathController.solveJsonPath);
 				exception(SearchJsonPathException.class, SearchJsonPathException.handleSearchJsonPathException);
@@ -92,7 +94,7 @@ public class Directory {
 				post("/fed-sparql", SparqlFederationController.solveSparqlQueryFederated);
 				exception(SearchSparqlException.class, SearchSparqlException.handleSearchSparqlException);
 			});
-			
+
 			path("/events", () -> {
 				get("", EventsController.subscribe);
 				get("/thing_created", EventsController.subscribeCreate);
@@ -115,10 +117,10 @@ public class Directory {
 				exception(Exception.class, Utils.handleException);
 			});
 		});
-		
+
 		redirect.get("", "/api/things");
 		redirect.get("/", "/api/things");
-		
+
 		// Unmatched Routes
 		notFound((Request request, Response response) ->  handleUnmatchedRoutes(request, response, 404));
 		internalServerError((Request request, Response response) ->  handleUnmatchedRoutes(request, response, 500));
@@ -130,7 +132,7 @@ public class Directory {
 			response.header("charset", "utf-8");
 		});
 	}
-	
+
 //	public static final Route redirect = (Request request, Response response) -> {
 //		//Redirect.
 //	}
@@ -139,7 +141,7 @@ public class Directory {
 			String format = request.headers(Utils.HEADER_ACCEPT);
 			JsonObject description = Utils.toJson(Utils.readFile(new File("self-description.json")));
 			String id = 	Utils.buildMessage("http://",request.raw().getServerName(), request.uri());
-			if(request.port()!=80) 
+			if(request.port()!=80)
 				id = Utils.buildMessage("http://",request.raw().getServerName(), ":", String.valueOf(request.port()), request.uri());
 
 			description.addProperty("@id", id);
@@ -151,11 +153,11 @@ public class Directory {
 				response.header(Utils.HEADER_CONTENT_TYPE, Utils.MIME_THING);
 			}
 			return description;
-			
+
 		}catch(Exception e) {
 			throw new SelfDescriptionException(e.toString());
 		}
-		
+
 		};
 
 	private static String handleUnmatchedRoutes(Request request, Response response, int status) {
@@ -170,14 +172,14 @@ public class Directory {
 		}
 		return "{\"message\":\"error\"}";
 	}
-	 
+
 
 	// -- Methods
 
 	public static DirectoryConfiguration getConfiguration() {
 		return configuration;
 	}
-	
+
 	public static void setConfiguration(DirectoryConfiguration newConfiguration) {
 		configuration = newConfiguration;
 		// Persist new configuration
@@ -188,7 +190,7 @@ public class Directory {
 			LOGGER.error(e.toString());
 		}
 	}
-	
+
 
 	private static final void setup() {
 		// logs configuration
@@ -199,7 +201,7 @@ public class Directory {
 			DirectoryConfiguration newConfiguration = DirectoryConfiguration.syncConfiguration();
 			setConfiguration(newConfiguration);
 			// Apply service configuration only-once
-			
+
 			port(configuration.getService().getPort());
 			threadPool(configuration.getService().getMaxThreads(), configuration.getService().getMinThreads(),
 					configuration.getService().getTimeOutMillis());
@@ -209,6 +211,6 @@ public class Directory {
 		}
 		// Show service info
 		LOGGER.info(Utils.WOT_DIRECTORY_LOGO);
-		
+
 	}
 }

--- a/src/main/java/directory/Utils.java
+++ b/src/main/java/directory/Utils.java
@@ -37,6 +37,7 @@ public class Utils {
 	public static final String MIME_CSV = "text/csv";
 	public static final String MIME_JSON = "application/json";
 	public static final String MIME_THING = "application/td+json";
+	public static final String MIME_LINK_FORMAT = "application/link-format";
 	public static final RDFFormat THING_RDFFormat = RDFFormat.JSONLD_FRAME_FLAT;
 	public static final String MIME_TURTLE = "text/turtle";
 	public static final String HEADER_CONTENT_TYPE = "Content-Type";


### PR DESCRIPTION
This PR changes the path for the retrieval of the directory's TD to `/.well-known/wot`, aligning it with the latest Discovery specification. It also adds supports for the CoRE Link-Format introduction method, which should remove its at-risk status once new test results are reported.

Accidentally, I auto-removed a lot of trailing whitespace and included it in one of the commits. I hope this is okay, otherwise I can clean up the commit.